### PR TITLE
Expose ImGuiListClipper and its members

### DIFF
--- a/cimgui/Makefile
+++ b/cimgui/Makefile
@@ -3,8 +3,9 @@
 # Compatible with Ubuntu 14.04.1 and Mac OS X
 
 OBJS = cimgui.o
-OBJS += fontAtlas.o 
+OBJS += fontAtlas.o
 OBJS += drawList.o
+OBJS += listClipper.o
 #OBJS += test.o
 OBJS += ../imgui/imgui.o
 OBJS += ../imgui/imgui_draw.o

--- a/cimgui/cimgui.h
+++ b/cimgui/cimgui.h
@@ -32,6 +32,7 @@ struct ImFont;
 struct ImFontConfig;
 struct ImFontAtlas;
 struct ImDrawCmd;
+struct ImGuiListClipper;
 
 typedef unsigned short ImDrawIdx;
 typedef unsigned int ImU32;
@@ -489,3 +490,8 @@ CIMGUI_API void             ImDrawList_PrimWriteIdx(struct ImDrawList* list, ImD
 CIMGUI_API void             ImDrawList_PrimVtx(struct ImDrawList* list, CONST struct ImVec2 pos, CONST struct ImVec2 uv, ImU32 col);
 CIMGUI_API void             ImDrawList_UpdateClipRect(struct ImDrawList* list);
 CIMGUI_API void             ImDrawList_UpdateTextureID(struct ImDrawList* list);
+
+// ImGuiListClipper
+CIMGUI_API void ImGuiListClipper_Begin(ImGuiListClipper* clipper, int count, float items_height);
+CIMGUI_API void ImGuiListClipper_End(ImGuiListClipper* clipper);
+CIMGUI_API bool ImGuiListClipper_Step(ImGuiListClipper* clipper);

--- a/cimgui/cimgui.h
+++ b/cimgui/cimgui.h
@@ -495,3 +495,5 @@ CIMGUI_API void             ImDrawList_UpdateTextureID(struct ImDrawList* list);
 CIMGUI_API void ImGuiListClipper_Begin(ImGuiListClipper* clipper, int count, float items_height);
 CIMGUI_API void ImGuiListClipper_End(ImGuiListClipper* clipper);
 CIMGUI_API bool ImGuiListClipper_Step(ImGuiListClipper* clipper);
+CIMGUI_API int ImGuiListClipper_GetDisplayStart(ImGuiListClipper* clipper);
+CIMGUI_API int ImGuiListClipper_GetDisplayEnd(ImGuiListClipper* clipper);

--- a/cimgui/listClipper.cpp
+++ b/cimgui/listClipper.cpp
@@ -1,0 +1,27 @@
+#include "../imgui/imgui.h"
+#include "cimgui.h"
+
+CIMGUI_API void ImGuiListClipper_Begin(ImGuiListClipper* clipper, int count, float items_height)
+{
+  clipper->Begin(count, items_height);
+}
+
+CIMGUI_API void ImGuiListClipper_End(ImGuiListClipper* clipper)
+{
+  clipper->End();
+}
+
+CIMGUI_API bool ImGuiListClipper_Step(ImGuiListClipper* clipper)
+{
+  return clipper->Step();
+}
+
+CIMGUI_API int ImGuiListClipper_GetDisplayStart(ImGuiListClipper* clipper)
+{
+  return clipper->DisplayStart;
+}
+
+CIMGUI_API int ImGuiListClipper_GetDisplayEnd(ImGuiListClipper* clipper)
+{
+  return clipper->DisplayEnd;
+}


### PR DESCRIPTION
This exposes the `ImGuiListClipper` members. The caller will still need to create a structure of appropriate size, but this is no different from the vector types.

I'm not sure whether `ImGuiListClipper_GetDisplayStart` and `ImGuiListClipper_GetDisplayEnd` are actually needed.

Usage example:

``` c
struct ImGuiListClipper {
  float StartPosY, ItemsHeight;
  int ItemsCount, StepNo, DisplayStart, DisplayEnd;
}
// ...
ImGuiListClipper clipper;
ImGuiListClipper_Begin(&clipper, lines, -1.0f);
while (ImGuiListClipper_Step(&clipper))
    for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
        igText("%i The quick brown fox jumps over the lazy dog\n", i);
ImGuiListClipper_End(&clipper);
```
