### PR TITLE
Add another batch of missing struct keywords, Add definition for ImDrawVert

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Most of the functions have wrapper counterparts now, missing stuff is added on a
 This library is intended as a intermediate layer to be able to use imgui from other languages that can interface with C (like D - see [D-binding](https://github.com/Extrawurst/DerelictImgui))
 
 Notes:
-* currently this wrapper is based on version [1.49 of imgui](https://github.com/ocornut/imgui/releases/tag/v1.49)
+* currently this wrapper is based on version [1.50 of imgui](https://github.com/ocornut/imgui/releases/tag/v1.50)
 * does not compile with pure C compiler yet (for writing bindings in languages that are able to use C-ABI it is enough though, see D-bindings)
 
 # usage
@@ -16,3 +16,10 @@ Notes:
 * make using makefile on linux/osx
 * use whatever method is in ImGui c++ namespace in the original [imgui.h](https://github.com/ocornut/imgui/blob/master/imgui.h) by prepending `ig`
 * methods have the same parameter list and return values (where possible)
+
+# example bindings based on cimgui
+
+* [DerelictImgui](https://github.com/Extrawurst/DerelictImgui)
+* [ImGui.NET](https://github.com/mellinoe/ImGui.NET)
+* [imgui-rs](https://github.com/Gekkio/imgui-rs)
+* [imgui-pas](https://github.com/dpethes/imgui-pas)

--- a/cimgui/cimgui.h
+++ b/cimgui/cimgui.h
@@ -365,6 +365,13 @@ struct ImDrawData {
     int                  TotalIdxCount;
 };
 
+struct ImDrawVert
+{
+    struct ImVec2  pos;
+    struct ImVec2  uv;
+    ImU32          col;
+};
+
 struct ImFontConfig {
     void*           FontData;
     int             FontDataSize;

--- a/cimgui/cimgui.h
+++ b/cimgui/cimgui.h
@@ -792,7 +792,7 @@ CIMGUI_API void             ImDrawList_AddCircleFilled(struct ImDrawList* list, 
 CIMGUI_API void             ImDrawList_AddText(struct ImDrawList* list, CONST struct ImVec2 pos, ImU32 col, CONST char* text_begin, CONST char* text_end);
 CIMGUI_API void             ImDrawList_AddTextExt(struct ImDrawList* list, CONST struct ImFont* font, float font_size, CONST struct ImVec2 pos, ImU32 col, CONST char* text_begin, CONST char* text_end, float wrap_width, CONST struct ImVec4* cpu_fine_clip_rect);
 CIMGUI_API void             ImDrawList_AddImage(struct ImDrawList* list, ImTextureID user_texture_id, CONST struct ImVec2 a, CONST struct ImVec2 b, CONST struct ImVec2 uv_a, CONST struct ImVec2 uv_b, ImU32 col);
-CIMGUI_API void             ImDrawList_AddImageQuad(struct ImDrawList* list, ImTextureID user_texture_id, CONST struct ImVec2 a, CONST ImVec2 b, CONST ImVec2 c, CONST ImVec2 d, CONST ImVec2 uv_a, CONST ImVec2 uv_b, CONST ImVec2 uv_c, CONST ImVec2 uv_d, ImU32 col);
+CIMGUI_API void             ImDrawList_AddImageQuad(struct ImDrawList* list, ImTextureID user_texture_id, CONST struct ImVec2 a, CONST struct ImVec2 b, CONST struct ImVec2 c, CONST struct ImVec2 d, CONST struct ImVec2 uv_a, CONST struct ImVec2 uv_b, CONST struct ImVec2 uv_c, CONST struct ImVec2 uv_d, ImU32 col);
 CIMGUI_API void             ImDrawList_AddPolyline(struct ImDrawList* list, CONST struct ImVec2* points, CONST int num_points, ImU32 col, bool closed, float thickness, bool anti_aliased);
 CIMGUI_API void             ImDrawList_AddConvexPolyFilled(struct ImDrawList* list, CONST struct ImVec2* points, CONST int num_points, ImU32 col, bool anti_aliased);
 CIMGUI_API void             ImDrawList_AddBezierCurve(struct ImDrawList* list, CONST struct ImVec2 pos0, CONST struct ImVec2 cp0, CONST struct ImVec2 cp1, CONST struct ImVec2 pos1, ImU32 col, float thickness, int num_segments);
@@ -829,11 +829,11 @@ CIMGUI_API void             ImDrawList_UpdateClipRect(struct ImDrawList* list);
 CIMGUI_API void             ImDrawList_UpdateTextureID(struct ImDrawList* list);
 
 // ImGuiListClipper
-CIMGUI_API void ImGuiListClipper_Begin(ImGuiListClipper* clipper, int count, float items_height);
-CIMGUI_API void ImGuiListClipper_End(ImGuiListClipper* clipper);
-CIMGUI_API bool ImGuiListClipper_Step(ImGuiListClipper* clipper);
-CIMGUI_API int ImGuiListClipper_GetDisplayStart(ImGuiListClipper* clipper);
-CIMGUI_API int ImGuiListClipper_GetDisplayEnd(ImGuiListClipper* clipper);
+CIMGUI_API void ImGuiListClipper_Begin(struct ImGuiListClipper* clipper, int count, float items_height);
+CIMGUI_API void ImGuiListClipper_End(struct ImGuiListClipper* clipper);
+CIMGUI_API bool ImGuiListClipper_Step(struct ImGuiListClipper* clipper);
+CIMGUI_API int ImGuiListClipper_GetDisplayStart(struct ImGuiListClipper* clipper);
+CIMGUI_API int ImGuiListClipper_GetDisplayEnd(struct ImGuiListClipper* clipper);
 
 // ImGuiTextFilter
 CIMGUI_API void	ImGuiTextFilter_Init(struct ImGuiTextFilter* filter, const char* default_filter);


### PR DESCRIPTION
Hi, I added some other missing **struct** as well as a definition for ImDrawVert, which was missing under the CIMGUI_DEFINE_ENUMS_AND_STRUCTS define.

With those changes, I can successfully compile cimgui with Visual Studio.
