### PR TITLE
Add ImGuilistClipper struct under CIMGUI_DEFINE_ENUMS_AND_STRUCTS

### DIFF
--- a/cimgui/cimgui.h
+++ b/cimgui/cimgui.h
@@ -387,6 +387,13 @@ struct ImFontConfig {
     char            Name[32];
     struct ImFont*  DstFont;
 };
+
+struct ImGuiListClipper
+{
+    float   StartPosY;
+    float   ItemsHeight;
+    int     ItemsCount, StepNo, DisplayStart, DisplayEnd;
+};
 #endif // CIMGUI_DEFINE_ENUMS_AND_STRUCTS
 
 CIMGUI_API struct ImGuiIO*         igGetIO();


### PR DESCRIPTION
Hello,

I had to add a definition for the list clipper struct under CIMGUI_DEFINE_ENUMS_AND_STRUCTS in order to reproduce [this memory editor example](https://github.com/ocornut/imgui/wiki/memory_editor_example).