### PR TITLE
Introduce CIMGUI_NO_EXPORT to stop exporting symbols

### DIFF
--- a/cimgui/cimgui.h
+++ b/cimgui/cimgui.h
@@ -2,8 +2,12 @@
 #include <stdio.h>
 
 #if defined _WIN32 || defined __CYGWIN__
+#ifdef CIMGUI_NO_EXPORT
+#define API
+#else
 #define API __declspec(dllexport)
-#ifndef __GNUC__
+#endif
+#ifdef __GNUC__
 #define snprintf sprintf_s
 #endif
 #else


### PR DESCRIPTION
Useful when static linking in a library to avoid collisions.

Resolves: https://github.com/Extrawurst/cimgui/issues/31