### PR TITLE
Update to imgui 1.51

### DIFF
--- a/cimgui/cimgui.cpp
+++ b/cimgui/cimgui.cpp
@@ -166,7 +166,7 @@ CIMGUI_API void igSetNextWindowSize(CONST ImVec2 size, ImGuiSetCond cond)
 
 CIMGUI_API void igSetNextWindowSizeConstraints(CONST struct ImVec2 size_min, CONST struct ImVec2 size_max, ImGuiSizeConstraintCallback custom_callback, void* custom_callback_data)
 {
-    ImGui::SetNextWindowSizeConstraints(size_min, size_max, custom_callback, custom_callback_data);   
+    ImGui::SetNextWindowSizeConstraints(size_min, size_max, custom_callback, custom_callback_data);
 }
 
 CIMGUI_API void igSetNextWindowContentSize(CONST ImVec2 size)
@@ -295,6 +295,11 @@ CIMGUI_API void igPopFont()
     return ImGui::PopFont();
 }
 
+CIMGUI_API void igPushStyleColor(ImGuiCol idx, ImU32 col)
+{
+    return ImGui::PushStyleColor(idx, col);
+}
+
 CIMGUI_API void igPushStyleColor(ImGuiCol idx, CONST ImVec4 col)
 {
     return ImGui::PushStyleColor(idx, col);
@@ -320,6 +325,11 @@ CIMGUI_API void igPopStyleVar(int count)
     return ImGui::PopStyleVar(count);
 }
 
+CIMGUI_API const ImVec4 igGetStyleColorVec4(ImGuiCol idx)
+{
+    return ImGui::GetStyleColorVec4(idx);
+}
+
 CIMGUI_API ImFont* igGetFont()
 {
     return ImGui::GetFont();
@@ -343,6 +353,11 @@ CIMGUI_API ImU32 igGetColorU32(ImGuiCol idx, float alpha_mul)
 CIMGUI_API ImU32 igGetColorU32Vec(CONST ImVec4* col)
 {
     return ImGui::GetColorU32(*col);
+}
+
+CIMGUI_API ImU32 igGetColorU32(ImU32 col)
+{
+    return ImGui::GetColorU32(col);
 }
 
 // Parameters stacks (current window)
@@ -436,9 +451,9 @@ CIMGUI_API bool igBeginPopupContextItem(CONST char* str_id, int mouse_button)
     return ImGui::BeginPopupContextItem(str_id, mouse_button);
 }
 
-CIMGUI_API bool igBeginPopupContextWindow(bool also_over_items, CONST char* str_id, int mouse_button)
+CIMGUI_API bool igBeginPopupContextWindow(CONST char* str_id, int mouse_button, bool also_over_items)
 {
-    return ImGui::BeginPopupContextWindow(also_over_items, str_id, mouse_button);
+    return ImGui::BeginPopupContextWindow(str_id, mouse_button, also_over_items);
 }
 
 CIMGUI_API bool igBeginPopupContextVoid(CONST char* str_id, int mouse_button)
@@ -449,6 +464,11 @@ CIMGUI_API bool igBeginPopupContextVoid(CONST char* str_id, int mouse_button)
 CIMGUI_API void igEndPopup()
 {
     return ImGui::EndPopup();
+}
+
+CIMGUI_API bool igIsPopupOpen(CONST char* str_id)
+{
+    return ImGui::IsPopupOpen(str_id);
 }
 
 CIMGUI_API void igCloseCurrentPopup()
@@ -585,6 +605,16 @@ CIMGUI_API int igGetColumnIndex()
     return ImGui::GetColumnIndex();
 }
 
+CIMGUI_API float igGetColumnWidth(int column_index)
+{
+    return ImGui::GetColumnWidth(column_index);
+}
+
+CIMGUI_API void igSetColumnWidth(int column_index, float width)
+{
+    return ImGui::SetColumnWidth(column_index, width);
+}
+
 CIMGUI_API float igGetColumnOffset(int column_index)
 {
     return ImGui::GetColumnOffset(column_index);
@@ -593,11 +623,6 @@ CIMGUI_API float igGetColumnOffset(int column_index)
 CIMGUI_API void igSetColumnOffset(int column_index, float offset_x)
 {
     return ImGui::SetColumnOffset(column_index, offset_x);
-}
-
-CIMGUI_API float igGetColumnWidth(int column_index)
-{
-    return ImGui::GetColumnWidth(column_index);
 }
 
 CIMGUI_API int igGetColumnsCount()
@@ -798,26 +823,6 @@ CIMGUI_API bool igCombo3(CONST char* label, int* current_item, bool(*items_gette
     return ImGui::Combo(label, current_item, items_getter, data, items_count, height_in_items);
 }
 
-CIMGUI_API bool igColorButton(CONST ImVec4 col, bool small_height, bool outline_border)
-{
-    return ImGui::ColorButton(col, small_height, outline_border);
-}
-
-CIMGUI_API bool igColorEdit3(CONST char* label, float col[3])
-{
-    return ImGui::ColorEdit3(label, col);
-}
-
-CIMGUI_API bool igColorEdit4(CONST char* label, float col[4], bool show_alpha)
-{
-    return ImGui::ColorEdit4(label, col, show_alpha);
-}
-
-CIMGUI_API void igColorEditMode(ImGuiColorEditMode mode)
-{
-    return ImGui::ColorEditMode(mode);
-}
-
 CIMGUI_API void igPlotLines(CONST char* label, CONST float* values, int values_count, int values_offset, CONST char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size, int stride)
 {
     return ImGui::PlotLines(label, values, values_count, values_offset, overlay_text, scale_min, scale_max, graph_size, stride);
@@ -897,6 +902,37 @@ CIMGUI_API bool igVSliderFloat(CONST char* label, CONST ImVec2 size, float* v, f
 CIMGUI_API bool igVSliderInt(CONST char* label, CONST ImVec2 size, int* v, int v_min, int v_max, CONST char* display_format)
 {
     return ImGui::VSliderInt(label, size, v, v_min, v_max, display_format);
+}
+
+// Widgets: Color Editor/Picker (tip: the ColorEdit* functions have a little colored preview square that can be left-clicked to open a picker, and right-clicked to open an option menu.)
+CIMGUI_API bool igColorEdit3(CONST char* label, float col[3], ImGuiColorEditFlags flags)
+{
+    return ImGui::ColorEdit3(label, col, flags);
+}
+
+CIMGUI_API bool igColorEdit4(CONST char* label, float col[4], ImGuiColorEditFlags flags)
+{
+    return ImGui::ColorEdit4(label, col, flags);
+}
+
+CIMGUI_API bool igColorPicker3(CONST char* label, float col[3], ImGuiColorEditFlags flags)
+{
+    return ImGui::ColorPicker3(label, col, flags);
+}
+
+CIMGUI_API bool igColorPicker4(CONST char* label, float col[4], ImGuiColorEditFlags flags, CONST float* ref_col)
+{
+    return ImGui::ColorPicker4(label, col, flags);
+}
+
+CIMGUI_API bool igColorButton(CONST char* desc_id, CONST ImVec4 col, ImGuiColorEditFlags flags, CONST ImVec2 size)
+{
+    return ImGui::ColorButton(desc_id, col, flags, size);
+}
+
+CIMGUI_API void igSetColorEditOptions(ImGuiColorEditFlags flags)
+{
+    return ImGui::SetColorEditOptions(flags);
 }
 
 // Widgets: Drags (tip: ctrl+click on a drag box to input text)
@@ -1098,7 +1134,7 @@ CIMGUI_API float igGetTreeNodeToLabelSpacing()
     return ImGui::GetTreeNodeToLabelSpacing();
 }
 
-CIMGUI_API void igSetNextTreeNodeOpen(bool opened, ImGuiSetCond cond)
+CIMGUI_API void igSetNextTreeNodeOpen(bool opened, ImGuiCond cond)
 {
     return ImGui::SetNextTreeNodeOpen(opened, cond);
 }
@@ -1273,9 +1309,9 @@ CIMGUI_API bool igIsItemHovered()
     return ImGui::IsItemHovered();
 }
 
-CIMGUI_API bool igIsItemHoveredRect()
+CIMGUI_API bool igIsRectItemHovered()
 {
-    return ImGui::IsItemHoveredRect();
+    return ImGui::IsRectItemHovered();
 }
 
 CIMGUI_API bool igIsItemActive()
@@ -1323,14 +1359,19 @@ CIMGUI_API void igSetItemAllowOverlap()
     ImGui::SetItemAllowOverlap();
 }
 
+CIMGUI_API bool igIsWindowFocused()
+{
+    return ImGui::IsWindowFocused();
+}
+
 CIMGUI_API bool igIsWindowHovered()
 {
     return ImGui::IsWindowHovered();
 }
 
-CIMGUI_API bool igIsWindowFocused()
+CIMGUI_API bool igIsWindowRectHovered()
 {
-    return ImGui::IsWindowFocused();
+    return ImGui::IsWindowRectHovered();
 }
 
 CIMGUI_API bool igIsRootWindowFocused()
@@ -1346,6 +1387,11 @@ CIMGUI_API bool igIsRootWindowOrAnyChildFocused()
 CIMGUI_API bool igIsRootWindowOrAnyChildHovered()
 {
     return ImGui::IsRootWindowOrAnyChildHovered();
+}
+
+CIMGUI_API bool igIsAnyWindowHovered()
+{
+    return ImGui::IsAnyWindowHovered();
 }
 
 CIMGUI_API bool igIsRectVisible(CONST ImVec2 item_size)
@@ -1398,28 +1444,14 @@ CIMGUI_API bool igIsMouseReleased(int button)
     return ImGui::IsMouseReleased(button);
 }
 
-CIMGUI_API bool igIsMouseHoveringWindow()
+CIMGUI_API bool igIsMouseDragging(int button, float lock_threshold)
 {
-    return ImGui::IsMouseHoveringWindow();
-}
-
-CIMGUI_API bool igIsMouseHoveringAnyWindow()
-{
-    return ImGui::IsMouseHoveringAnyWindow();
+    return ImGui::IsMouseDragging(button,lock_threshold);
 }
 
 CIMGUI_API bool igIsMouseHoveringRect(CONST ImVec2 r_min, CONST ImVec2 r_max, bool clip)
 {
     return ImGui::IsMouseHoveringRect(r_min,r_max,clip);
-}
-
-CIMGUI_API bool igIsMouseDragging(int button, float lock_threshold)
-{
-    return ImGui::IsMouseDragging(button,lock_threshold);
-}
-CIMGUI_API bool igIsPosHoveringAnyWindow(CONST ImVec2 pos)
-{
-    return ImGui::IsPosHoveringAnyWindow(pos);
 }
 
 CIMGUI_API void igGetMousePos(ImVec2* pOut)
@@ -1492,9 +1524,9 @@ CIMGUI_API int igGetFrameCount()
     return ImGui::GetFrameCount();
 }
 
-CIMGUI_API CONST char* igGetStyleColName(ImGuiCol idx)
+CIMGUI_API CONST char* igGetStyleColorName(ImGuiCol idx)
 {
-    return ImGui::GetStyleColName(idx);
+    return ImGui::GetStyleColorName(idx);
 }
 
 CIMGUI_API void igCalcItemRectClosestPoint(ImVec2* pOut, CONST ImVec2 pos, bool on_edge, float outward)
@@ -1656,7 +1688,7 @@ CIMGUI_API void ImGuiStorage_SetBool(struct ImGuiStorage* storage, ImGuiID key, 
 	storage->SetBool(key, val);
 }
 
-CIMGUI_API float ImGuiStorage_GetFloat(struct ImGuiStorage* storage, ImGuiID key, float default_val) 
+CIMGUI_API float ImGuiStorage_GetFloat(struct ImGuiStorage* storage, ImGuiID key, float default_val)
 {
 	return storage->GetFloat(key, default_val);
 }
@@ -1666,7 +1698,7 @@ CIMGUI_API void ImGuiStorage_SetFloat(struct ImGuiStorage* storage, ImGuiID key,
 	storage->SetFloat(key, val);
 }
 
-CIMGUI_API void* ImGuiStorage_GetVoidPtr(struct ImGuiStorage* storage, ImGuiID key) 
+CIMGUI_API void* ImGuiStorage_GetVoidPtr(struct ImGuiStorage* storage, ImGuiID key)
 {
 	return storage->GetVoidPtr(key);
 }
@@ -1681,7 +1713,7 @@ CIMGUI_API int* ImGuiStorage_GetIntRef(struct ImGuiStorage* storage, ImGuiID key
 	return storage->GetIntRef(key, default_val);
 }
 
-CIMGUI_API bool* ImGuiStorage_GetBoolRef(struct ImGuiStorage* storage, ImGuiID key, bool default_val) 
+CIMGUI_API bool* ImGuiStorage_GetBoolRef(struct ImGuiStorage* storage, ImGuiID key, bool default_val)
 {
 	return storage->GetBoolRef(key, default_val);
 }

--- a/cimgui/cimgui.cpp
+++ b/cimgui/cimgui.cpp
@@ -149,17 +149,17 @@ CIMGUI_API void igSetWindowFontScale(float scale)
     ImGui::SetWindowFontScale(scale);
 }
 
-CIMGUI_API void igSetNextWindowPos(CONST ImVec2 pos, ImGuiSetCond cond)
+CIMGUI_API void igSetNextWindowPos(CONST ImVec2 pos, ImGuiCond cond)
 {
     ImGui::SetNextWindowPos(pos, cond);
 }
 
-CIMGUI_API void igSetNextWindowPosCenter(ImGuiSetCond cond)
+CIMGUI_API void igSetNextWindowPosCenter(ImGuiCond cond)
 {
     ImGui::SetNextWindowPosCenter(cond);
 }
 
-CIMGUI_API void igSetNextWindowSize(CONST ImVec2 size, ImGuiSetCond cond)
+CIMGUI_API void igSetNextWindowSize(CONST ImVec2 size, ImGuiCond cond)
 {
     ImGui::SetNextWindowSize(size, cond);
 }
@@ -179,7 +179,7 @@ CIMGUI_API void igSetNextWindowContentWidth(float width)
     ImGui::SetNextWindowContentWidth(width);
 }
 
-CIMGUI_API void igSetNextWindowCollapsed(bool collapsed, ImGuiSetCond cond)
+CIMGUI_API void igSetNextWindowCollapsed(bool collapsed, ImGuiCond cond)
 {
     ImGui::SetNextWindowCollapsed(collapsed,cond);
 }
@@ -189,17 +189,17 @@ CIMGUI_API void igSetNextWindowFocus()
     ImGui::SetNextWindowFocus();
 }
 
-CIMGUI_API void igSetWindowPos(CONST ImVec2 pos, ImGuiSetCond cond)
+CIMGUI_API void igSetWindowPos(CONST ImVec2 pos, ImGuiCond cond)
 {
     ImGui::SetWindowPos(pos,cond);
 }
 
-CIMGUI_API void igSetWindowSize(CONST ImVec2 size, ImGuiSetCond cond)
+CIMGUI_API void igSetWindowSize(CONST ImVec2 size, ImGuiCond cond)
 {
     ImGui::SetWindowSize(size, cond);
 }
 
-CIMGUI_API void igSetWindowCollapsed(bool collapsed, ImGuiSetCond cond)
+CIMGUI_API void igSetWindowCollapsed(bool collapsed, ImGuiCond cond)
 {
     ImGui::SetWindowCollapsed(collapsed,cond);
 }
@@ -209,17 +209,17 @@ CIMGUI_API void igSetWindowFocus()
     ImGui::SetWindowFocus();
 }
 
-CIMGUI_API void igSetWindowPosByName(CONST char* name, CONST ImVec2 pos, ImGuiSetCond cond)
+CIMGUI_API void igSetWindowPosByName(CONST char* name, CONST ImVec2 pos, ImGuiCond cond)
 {
     ImGui::SetWindowPos(name,pos,cond);
 }
 
-CIMGUI_API void igSetWindowSize2(CONST char* name, CONST ImVec2 size, ImGuiSetCond cond)
+CIMGUI_API void igSetWindowSize2(CONST char* name, CONST ImVec2 size, ImGuiCond cond)
 {
     ImGui::SetWindowSize(name, size, cond);
 }
 
-CIMGUI_API void igSetWindowCollapsed2(CONST char* name, bool collapsed, ImGuiSetCond cond)
+CIMGUI_API void igSetWindowCollapsed2(CONST char* name, bool collapsed, ImGuiCond cond)
 {
     ImGui::SetWindowCollapsed(name, collapsed, cond);
 }
@@ -295,7 +295,7 @@ CIMGUI_API void igPopFont()
     return ImGui::PopFont();
 }
 
-CIMGUI_API void igPushStyleColor(ImGuiCol idx, ImU32 col)
+CIMGUI_API void igPushStyleColorU32(ImGuiCol idx, ImU32 col)
 {
     return ImGui::PushStyleColor(idx, col);
 }
@@ -325,9 +325,9 @@ CIMGUI_API void igPopStyleVar(int count)
     return ImGui::PopStyleVar(count);
 }
 
-CIMGUI_API const ImVec4 igGetStyleColorVec4(ImGuiCol idx)
+CIMGUI_API void igGetStyleColorVec4(ImVec4* pOut, ImGuiCol idx)
 {
-    return ImGui::GetStyleColorVec4(idx);
+    *pOut = ImGui::GetStyleColorVec4(idx);
 }
 
 CIMGUI_API ImFont* igGetFont()
@@ -355,7 +355,7 @@ CIMGUI_API ImU32 igGetColorU32Vec(CONST ImVec4* col)
     return ImGui::GetColorU32(*col);
 }
 
-CIMGUI_API ImU32 igGetColorU32(ImU32 col)
+CIMGUI_API ImU32 igGetColorU32U32(ImU32 col)
 {
     return ImGui::GetColorU32(col);
 }
@@ -1246,16 +1246,6 @@ CIMGUI_API void igValueFloat(CONST char* prefix, float v, CONST char* float_form
     ImGui::Value(prefix,v,float_format);
 }
 
-CIMGUI_API void igValueColor(CONST char* prefix, CONST ImVec4 v)
-{
-    ImGui::ValueColor(prefix,v);
-}
-
-CIMGUI_API void igValueColor2(CONST char* prefix, ImU32 v)
-{
-    ImGui::ValueColor(prefix,v);
-}
-
 // Logging: all text output from interface is redirected to tty/file/clipboard. Tree nodes are automatically opened.
 CIMGUI_API void igLogToTTY(int max_depth)
 {
@@ -1309,9 +1299,9 @@ CIMGUI_API bool igIsItemHovered()
     return ImGui::IsItemHovered();
 }
 
-CIMGUI_API bool igIsRectItemHovered()
+CIMGUI_API bool igIsItemRectHovered()
 {
-    return ImGui::IsRectItemHovered();
+    return ImGui::IsItemRectHovered();
 }
 
 CIMGUI_API bool igIsItemActive()

--- a/cimgui/cimgui.h
+++ b/cimgui/cimgui.h
@@ -43,22 +43,28 @@ struct ImGuiTextFilter;
 
 typedef unsigned short ImDrawIdx;
 typedef unsigned int ImU32;
-typedef unsigned short ImWchar;     
-typedef void* ImTextureID;       
-typedef ImU32 ImGuiID;              
-typedef int ImGuiCol;               
-typedef int ImGuiStyleVar;          
-typedef int ImGuiKey;               
-typedef int ImGuiColorEditMode;     
-typedef int ImGuiMouseCursor;       
-typedef int ImGuiWindowFlags;       
-typedef int ImGuiSetCond;           
-typedef int ImGuiInputTextFlags;    
-typedef int ImGuiSelectableFlags;   
-typedef int ImGuiTreeNodeFlags;     
+typedef unsigned short ImWchar;
+typedef void* ImTextureID;
+typedef ImU32 ImGuiID;
+typedef int ImGuiCol;
+typedef int ImGuiStyleVar;
+typedef int ImGuiKey;
+typedef int ImGuiColorEditFlags;
+typedef int ImGuiMouseCursor;
+typedef int ImGuiWindowFlags;
+typedef int ImGuiCond;
+typedef int ImGuiColumnsFlags;
+typedef int ImGuiInputTextFlags;
+typedef int ImGuiSelectableFlags;
+typedef int ImGuiTreeNodeFlags;
 typedef int (*ImGuiTextEditCallback)(struct ImGuiTextEditCallbackData *data);
 typedef void (*ImGuiSizeConstraintCallback)(struct ImGuiSizeConstraintCallbackData* data);
 typedef void (*ImDrawCallback)(CONST struct ImDrawList* parent_list, CONST struct ImDrawCmd* cmd);
+#ifdef _MSC_VER
+typedef unsigned __int64 ImU64;
+#else
+typedef unsigned long long ImU64;
+#endif
 
 #ifdef CIMGUI_DEFINE_ENUMS_AND_STRUCTS
 struct ImVec2 {
@@ -180,9 +186,9 @@ enum {
     ImGuiCol_Header,
     ImGuiCol_HeaderHovered,
     ImGuiCol_HeaderActive,
-    ImGuiCol_Column,
-    ImGuiCol_ColumnHovered,
-    ImGuiCol_ColumnActive,
+    ImGuiCol_Separator,
+    ImGuiCol_SeparatorHovered,
+    ImGuiCol_SeparatorActive,
     ImGuiCol_ResizeGrip,
     ImGuiCol_ResizeGripHovered,
     ImGuiCol_ResizeGripActive,
@@ -215,11 +221,25 @@ enum {
 };
 
 enum {
-    ImGuiColorEditMode_UserSelect = -2,
-    ImGuiColorEditMode_UserSelectShowButton = -1,
-    ImGuiColorEditMode_RGB = 0,
-    ImGuiColorEditMode_HSV = 1,
-    ImGuiColorEditMode_HEX = 2
+    ImGuiColorEditFlags_NoAlpha         = 1 << 1,
+    ImGuiColorEditFlags_NoPicker        = 1 << 2,
+    ImGuiColorEditFlags_NoOptions       = 1 << 3,
+    ImGuiColorEditFlags_NoSmallPreview  = 1 << 4,
+    ImGuiColorEditFlags_NoInputs        = 1 << 5,
+    ImGuiColorEditFlags_NoTooltip       = 1 << 6,
+    ImGuiColorEditFlags_NoLabel         = 1 << 7,
+    ImGuiColorEditFlags_NoSidePreview   = 1 << 8,
+    ImGuiColorEditFlags_AlphaBar        = 1 << 9,
+    ImGuiColorEditFlags_AlphaPreview    = 1 << 10,
+    ImGuiColorEditFlags_AlphaPreviewHalf= 1 << 11,
+    ImGuiColorEditFlags_HDR             = 1 << 12,
+    ImGuiColorEditFlags_RGB             = 1 << 13,
+    ImGuiColorEditFlags_HSV             = 1 << 14,
+    ImGuiColorEditFlags_HEX             = 1 << 15,
+    ImGuiColorEditFlags_Uint8           = 1 << 16,
+    ImGuiColorEditFlags_Float           = 1 << 17,
+    ImGuiColorEditFlags_PickerHueBar    = 1 << 18,
+    ImGuiColorEditFlags_PickerHueWheel  = 1 << 19
 };
 
 enum {
@@ -235,10 +255,10 @@ enum {
 };
 
 enum {
-    ImGuiSetCond_Always        = 1 << 0,
-    ImGuiSetCond_Once          = 1 << 1,
-    ImGuiSetCond_FirstUseEver  = 1 << 2,
-    ImGuiSetCond_Appearing     = 1 << 3
+    ImGuiCond_Always        = 1 << 0,
+    ImGuiCond_Once          = 1 << 1,
+    ImGuiCond_FirstUseEver  = 1 << 2,
+    ImGuiCond_Appearing     = 1 << 3
 };
 
 struct ImGuiStyle {
@@ -464,16 +484,19 @@ CIMGUI_API struct ImGuiStorage*    igGetStateStorage();
 // Parameters stacks (shared)
 CIMGUI_API void             igPushFont(struct ImFont* font);
 CIMGUI_API void             igPopFont();
+CIMGUI_API void             igPushStyleColor(ImGuiCol idx, ImU32 col);
 CIMGUI_API void             igPushStyleColor(ImGuiCol idx, CONST struct ImVec4 col);
 CIMGUI_API void             igPopStyleColor(int count);
 CIMGUI_API void             igPushStyleVar(ImGuiStyleVar idx, float val);
 CIMGUI_API void             igPushStyleVarVec(ImGuiStyleVar idx, CONST struct ImVec2 val);
 CIMGUI_API void             igPopStyleVar(int count);
+CIMGUI_API CONST struct ImVec4 igGetStyleColorVec4(ImGuiCol idx);
 CIMGUI_API struct ImFont*          igGetFont();
 CIMGUI_API float            igGetFontSize();
 CIMGUI_API void             igGetFontTexUvWhitePixel(struct ImVec2* pOut);
 CIMGUI_API ImU32            igGetColorU32(ImGuiCol idx, float alpha_mul);
 CIMGUI_API ImU32            igGetColorU32Vec(CONST struct ImVec4* col);
+CIMGUI_API ImU32            igGetColorU32(ImU32 col);
 
 
 // Parameters stacks (current window)
@@ -515,9 +538,10 @@ CIMGUI_API float            igGetItemsLineHeightWithSpacing();
 CIMGUI_API void             igColumns(int count, CONST char* id, bool border);
 CIMGUI_API void             igNextColumn();
 CIMGUI_API int              igGetColumnIndex();
+CIMGUI_API float            igGetColumnWidth(int column_index);                               // get column width (in pixels). pass -1 to use current column
+CIMGUI_API void             igSetColumnWidth(int column_index, float width);
 CIMGUI_API float            igGetColumnOffset(int column_index);
 CIMGUI_API void             igSetColumnOffset(int column_index, float offset_x);
-CIMGUI_API float            igGetColumnWidth(int column_index);
 CIMGUI_API int              igGetColumnsCount();
 
 // ID scopes
@@ -559,10 +583,6 @@ CIMGUI_API bool             igRadioButton(CONST char* label, int* v, int v_butto
 CIMGUI_API bool             igCombo(CONST char* label, int* current_item, CONST char* CONST* items, int items_count, int height_in_items);
 CIMGUI_API bool             igCombo2(CONST char* label, int* current_item, CONST char* items_separated_by_zeros, int height_in_items);
 CIMGUI_API bool             igCombo3(CONST char* label, int* current_item, bool(*items_getter)(void* data, int idx, CONST char** out_text), void* data, int items_count, int height_in_items);
-CIMGUI_API bool             igColorButton(CONST struct ImVec4 col, bool small_height, bool outline_border);
-CIMGUI_API bool             igColorEdit3(CONST char* label, float col[3]);
-CIMGUI_API bool             igColorEdit4(CONST char* label, float col[4], bool show_alpha);
-CIMGUI_API void             igColorEditMode(ImGuiColorEditMode mode);
 CIMGUI_API void             igPlotLines(CONST char* label, CONST float* values, int values_count, int values_offset, CONST char* overlay_text, float scale_min, float scale_max, struct ImVec2 graph_size, int stride);
 CIMGUI_API void             igPlotLines2(CONST char* label, float(*values_getter)(void* data, int idx), void* data, int values_count, int values_offset, CONST char* overlay_text, float scale_min, float scale_max, struct ImVec2 graph_size);
 CIMGUI_API void             igPlotHistogram(CONST char* label, CONST float* values, int values_count, int values_offset, CONST char* overlay_text, float scale_min, float scale_max, struct ImVec2 graph_size, int stride);
@@ -582,6 +602,15 @@ CIMGUI_API bool             igSliderInt3(CONST char* label, int v[3], int v_min,
 CIMGUI_API bool             igSliderInt4(CONST char* label, int v[4], int v_min, int v_max, CONST char* display_format);
 CIMGUI_API bool             igVSliderFloat(CONST char* label, CONST struct ImVec2 size, float* v, float v_min, float v_max, CONST char* display_format, float power);
 CIMGUI_API bool             igVSliderInt(CONST char* label, CONST struct ImVec2 size, int* v, int v_min, int v_max, CONST char* display_format);
+
+// Widgets: Color Editor/Picker (tip: the ColorEdit* functions have a little colored preview square that can be left-clicked to open a picker, and right-clicked to open an option menu.)
+CIMGUI_API bool             igColorEdit3(CONST char* label, float col[3], ImGuiColorEditFlags flags);
+CIMGUI_API bool             igColorEdit4(CONST char* label, float col[4], ImGuiColorEditFlags flags);
+CIMGUI_API bool             igColorPicker3(CONST char* label, float col[3], ImGuiColorEditFlags flags);
+CIMGUI_API bool             igColorPicker4(CONST char* label, float col[4], ImGuiColorEditFlags flags, CONST float* ref_col);
+CIMGUI_API bool             igColorButton(CONST char* desc_id, CONST struct ImVec4 col, ImGuiColorEditFlags flags, CONST struct ImVec2 size);
+CIMGUI_API void             igSetColorEditOptions(ImGuiColorEditFlags flags);
+
 
 // Widgets: Drags (tip: ctrl+click on a drag box to input text)
 CIMGUI_API bool             igDragFloat(CONST char* label, float* v, float v_speed, float v_min, float v_max, CONST char* display_format, float power);     // If v_max >= v_max we have no bound
@@ -624,7 +653,7 @@ CIMGUI_API void             igTreePushPtr(CONST void* ptr_id);
 CIMGUI_API void             igTreePop();
 CIMGUI_API void             igTreeAdvanceToLabelPos();
 CIMGUI_API float            igGetTreeNodeToLabelSpacing();
-CIMGUI_API void             igSetNextTreeNodeOpen(bool opened, ImGuiSetCond cond);
+CIMGUI_API void             igSetNextTreeNodeOpen(bool opened, ImGuiCond cond);
 CIMGUI_API bool             igCollapsingHeader(CONST char* label, ImGuiTreeNodeFlags flags);
 CIMGUI_API bool             igCollapsingHeaderEx(CONST char* label, bool* p_open, ImGuiTreeNodeFlags flags);
 
@@ -666,9 +695,10 @@ CIMGUI_API void             igOpenPopup(CONST char* str_id);
 CIMGUI_API bool             igBeginPopup(CONST char* str_id);
 CIMGUI_API bool             igBeginPopupModal(CONST char* name, bool* p_open, ImGuiWindowFlags extra_flags);
 CIMGUI_API bool             igBeginPopupContextItem(CONST char* str_id, int mouse_button);
-CIMGUI_API bool             igBeginPopupContextWindow(bool also_over_items, CONST char* str_id, int mouse_button);
+CIMGUI_API bool             igBeginPopupContextWindow(CONST char* str_id, int mouse_button, bool also_over_items);
 CIMGUI_API bool             igBeginPopupContextVoid(CONST char* str_id, int mouse_button);
 CIMGUI_API void             igEndPopup();
+CIMGUI_API bool             igIsPopupOpen(CONST char* str_id);
 CIMGUI_API void             igCloseCurrentPopup();
 
 // Logging: all text output from interface is redirected to tty/file/clipboard. Tree nodes are automatically opened.
@@ -685,7 +715,7 @@ CIMGUI_API void             igPopClipRect();
 
 // Utilities
 CIMGUI_API bool             igIsItemHovered();
-CIMGUI_API bool             igIsItemHoveredRect();
+CIMGUI_API bool             igIsRectItemHovered();
 CIMGUI_API bool             igIsItemActive();
 CIMGUI_API bool             igIsItemClicked(int mouse_button);
 CIMGUI_API bool             igIsItemVisible();
@@ -695,17 +725,18 @@ CIMGUI_API void             igGetItemRectMin(struct ImVec2* pOut);
 CIMGUI_API void             igGetItemRectMax(struct ImVec2* pOut);
 CIMGUI_API void             igGetItemRectSize(struct ImVec2* pOut);
 CIMGUI_API void             igSetItemAllowOverlap();
-CIMGUI_API bool             igIsWindowHovered();
 CIMGUI_API bool             igIsWindowFocused();
+CIMGUI_API bool             igIsWindowHovered();
+CIMGUI_API bool             igIsWindowRectHovered();
 CIMGUI_API bool             igIsRootWindowFocused();
 CIMGUI_API bool             igIsRootWindowOrAnyChildFocused();
 CIMGUI_API bool             igIsRootWindowOrAnyChildHovered();
+CIMGUI_API bool             igIsAnyWindowHovered();
 CIMGUI_API bool             igIsRectVisible(CONST struct ImVec2 item_size);
 CIMGUI_API bool             igIsRectVisible2(CONST struct ImVec2* rect_min, CONST struct ImVec2* rect_max);
-CIMGUI_API bool             igIsPosHoveringAnyWindow(CONST struct ImVec2 pos);
 CIMGUI_API float            igGetTime();
 CIMGUI_API int              igGetFrameCount();
-CIMGUI_API CONST char*      igGetStyleColName(ImGuiCol idx);
+CIMGUI_API CONST char*      igGetStyleColorName(ImGuiCol idx);
 CIMGUI_API void             igCalcItemRectClosestPoint(struct ImVec2* pOut, CONST struct ImVec2 pos, bool on_edge, float outward);
 CIMGUI_API void             igCalcTextSize(struct ImVec2* pOut, CONST char* text, CONST char* text_end, bool hide_text_after_double_hash, float wrap_width);
 CIMGUI_API void             igCalcListClipping(int items_count, float items_height, int* out_items_display_start, int* out_items_display_end);
@@ -726,10 +757,8 @@ CIMGUI_API bool             igIsMouseDown(int button);
 CIMGUI_API bool             igIsMouseClicked(int button, bool repeat);
 CIMGUI_API bool             igIsMouseDoubleClicked(int button);
 CIMGUI_API bool             igIsMouseReleased(int button);
-CIMGUI_API bool             igIsMouseHoveringWindow();
-CIMGUI_API bool             igIsMouseHoveringAnyWindow();
-CIMGUI_API bool             igIsMouseHoveringRect(CONST struct ImVec2 r_min, CONST struct ImVec2 r_max, bool clip);
 CIMGUI_API bool             igIsMouseDragging(int button, float lock_threshold);
+CIMGUI_API bool             igIsMouseHoveringRect(CONST struct ImVec2 r_min, CONST struct ImVec2 r_max, bool clip);
 CIMGUI_API void             igGetMousePos(struct ImVec2* pOut);
 CIMGUI_API void             igGetMousePosOnOpeningCurrentPopup(struct ImVec2* pOut);
 CIMGUI_API void             igGetMouseDragDelta(struct ImVec2* pOut, int button, float lock_threshold);
@@ -760,9 +789,9 @@ CIMGUI_API void             ImFontAtlas_SetTexID(struct ImFontAtlas* atlas, ImTe
 CIMGUI_API struct ImFont*   ImFontAtlas_AddFont(struct ImFontAtlas* atlas, CONST struct ImFontConfig* font_cfg);
 CIMGUI_API struct ImFont*   ImFontAtlas_AddFontDefault(struct ImFontAtlas* atlas, CONST struct ImFontConfig* font_cfg);
 CIMGUI_API struct ImFont*   ImFontAtlas_AddFontFromFileTTF(struct ImFontAtlas* atlas, CONST char* filename, float size_pixels, CONST struct ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges);
-CIMGUI_API struct ImFont*   ImFontAtlas_AddFontFromMemoryTTF(struct ImFontAtlas* atlas, void* ttf_data, int ttf_size, float size_pixels, CONST struct ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges);
-CIMGUI_API struct ImFont*   ImFontAtlas_AddFontFromMemoryCompressedTTF(struct ImFontAtlas* atlas, CONST void* compressed_ttf_data, int compressed_ttf_size, float size_pixels, CONST struct ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges);
-CIMGUI_API struct ImFont*   ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(struct ImFontAtlas* atlas, CONST char* compressed_ttf_data_base85, float size_pixels, CONST struct ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges);
+CIMGUI_API struct ImFont*   ImFontAtlas_AddFontFromMemoryTTF(struct ImFontAtlas* atlas, void* font_data, int font_size, float size_pixels, CONST struct ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges);
+CIMGUI_API struct ImFont*   ImFontAtlas_AddFontFromMemoryCompressedTTF(struct ImFontAtlas* atlas, CONST void* compressed_font_data, int compressed_font_size, float size_pixels, CONST struct ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges);
+CIMGUI_API struct ImFont*   ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(struct ImFontAtlas* atlas, CONST char* compressed_font_data_base85, float size_pixels, CONST struct ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges);
 CIMGUI_API void             ImFontAtlas_ClearTexData(struct ImFontAtlas* atlas);
 CIMGUI_API void             ImFontAtlas_Clear(struct ImFontAtlas* atlas);
 CIMGUI_API CONST ImWchar*   ImFontAtlas_GetGlyphRangesDefault(struct ImFontAtlas* atlas);
@@ -795,6 +824,8 @@ CIMGUI_API void             ImDrawList_PushClipRectFullScreen(struct ImDrawList*
 CIMGUI_API void             ImDrawList_PopClipRect(struct ImDrawList* list);
 CIMGUI_API void             ImDrawList_PushTextureID(struct ImDrawList* list, CONST ImTextureID texture_id);
 CIMGUI_API void             ImDrawList_PopTextureID(struct ImDrawList* list);
+CIMGUI_API struct ImVec2    ImDrawList_GetClipRectMin(struct ImDrawList* list);
+CIMGUI_API struct ImVec2    ImDrawList_GetClipRectMax(struct ImDrawList* list);
 
 // Primitives
 CIMGUI_API void             ImDrawList_AddLine(struct ImDrawList* list, CONST struct ImVec2 a, CONST struct ImVec2 b, ImU32 col, float thickness);

--- a/cimgui/cimgui.h
+++ b/cimgui/cimgui.h
@@ -452,21 +452,21 @@ CIMGUI_API float            igGetWindowHeight();
 CIMGUI_API bool             igIsWindowCollapsed();
 CIMGUI_API void             igSetWindowFontScale(float scale);
 
-CIMGUI_API void             igSetNextWindowPos(CONST struct ImVec2 pos, ImGuiSetCond cond);
-CIMGUI_API void             igSetNextWindowPosCenter(ImGuiSetCond cond);
-CIMGUI_API void             igSetNextWindowSize(CONST struct ImVec2 size, ImGuiSetCond cond);
+CIMGUI_API void             igSetNextWindowPos(CONST struct ImVec2 pos, ImGuiCond cond);
+CIMGUI_API void             igSetNextWindowPosCenter(ImGuiCond cond);
+CIMGUI_API void             igSetNextWindowSize(CONST struct ImVec2 size, ImGuiCond cond);
 CIMGUI_API void             igSetNextWindowSizeConstraints(CONST struct ImVec2 size_min, CONST struct ImVec2 size_max, ImGuiSizeConstraintCallback custom_callback, void* custom_callback_data);
 CIMGUI_API void             igSetNextWindowContentSize(CONST struct ImVec2 size);
 CIMGUI_API void             igSetNextWindowContentWidth(float width);
-CIMGUI_API void             igSetNextWindowCollapsed(bool collapsed, ImGuiSetCond cond);
+CIMGUI_API void             igSetNextWindowCollapsed(bool collapsed, ImGuiCond cond);
 CIMGUI_API void             igSetNextWindowFocus();
-CIMGUI_API void             igSetWindowPos(CONST struct ImVec2 pos, ImGuiSetCond cond);
-CIMGUI_API void             igSetWindowSize(CONST struct ImVec2 size, ImGuiSetCond cond);
-CIMGUI_API void             igSetWindowCollapsed(bool collapsed, ImGuiSetCond cond);
+CIMGUI_API void             igSetWindowPos(CONST struct ImVec2 pos, ImGuiCond cond);
+CIMGUI_API void             igSetWindowSize(CONST struct ImVec2 size, ImGuiCond cond);
+CIMGUI_API void             igSetWindowCollapsed(bool collapsed, ImGuiCond cond);
 CIMGUI_API void             igSetWindowFocus();
-CIMGUI_API void             igSetWindowPosByName(CONST char* name, CONST struct ImVec2 pos, ImGuiSetCond cond);
-CIMGUI_API void             igSetWindowSize2(CONST char* name, CONST struct ImVec2 size, ImGuiSetCond cond);
-CIMGUI_API void             igSetWindowCollapsed2(CONST char* name, bool collapsed, ImGuiSetCond cond);
+CIMGUI_API void             igSetWindowPosByName(CONST char* name, CONST struct ImVec2 pos, ImGuiCond cond);
+CIMGUI_API void             igSetWindowSize2(CONST char* name, CONST struct ImVec2 size, ImGuiCond cond);
+CIMGUI_API void             igSetWindowCollapsed2(CONST char* name, bool collapsed, ImGuiCond cond);
 CIMGUI_API void             igSetWindowFocus2(CONST char* name);
 
 CIMGUI_API float            igGetScrollX();
@@ -484,19 +484,19 @@ CIMGUI_API struct ImGuiStorage*    igGetStateStorage();
 // Parameters stacks (shared)
 CIMGUI_API void             igPushFont(struct ImFont* font);
 CIMGUI_API void             igPopFont();
-CIMGUI_API void             igPushStyleColor(ImGuiCol idx, ImU32 col);
+CIMGUI_API void             igPushStyleColorU32(ImGuiCol idx, ImU32 col);
 CIMGUI_API void             igPushStyleColor(ImGuiCol idx, CONST struct ImVec4 col);
 CIMGUI_API void             igPopStyleColor(int count);
 CIMGUI_API void             igPushStyleVar(ImGuiStyleVar idx, float val);
 CIMGUI_API void             igPushStyleVarVec(ImGuiStyleVar idx, CONST struct ImVec2 val);
 CIMGUI_API void             igPopStyleVar(int count);
-CIMGUI_API CONST struct ImVec4 igGetStyleColorVec4(ImGuiCol idx);
-CIMGUI_API struct ImFont*          igGetFont();
+CIMGUI_API void             igGetStyleColorVec4(struct ImVec4 *pOut, ImGuiCol idx);
+CIMGUI_API struct ImFont*   igGetFont();
 CIMGUI_API float            igGetFontSize();
 CIMGUI_API void             igGetFontTexUvWhitePixel(struct ImVec2* pOut);
 CIMGUI_API ImU32            igGetColorU32(ImGuiCol idx, float alpha_mul);
 CIMGUI_API ImU32            igGetColorU32Vec(CONST struct ImVec4* col);
-CIMGUI_API ImU32            igGetColorU32(ImU32 col);
+CIMGUI_API ImU32            igGetColorU32U32(ImU32 col);
 
 
 // Parameters stacks (current window)
@@ -671,8 +671,6 @@ CIMGUI_API void             igValueBool(CONST char* prefix, bool b);
 CIMGUI_API void             igValueInt(CONST char* prefix, int v);
 CIMGUI_API void             igValueUInt(CONST char* prefix, unsigned int v);
 CIMGUI_API void             igValueFloat(CONST char* prefix, float v, CONST char* float_format);
-CIMGUI_API void             igValueColor(CONST char* prefix, CONST struct ImVec4 v);
-CIMGUI_API void             igValueColor2(CONST char* prefix, ImU32 v);
 
 // Tooltip
 CIMGUI_API void             igSetTooltip(CONST char* fmt, ...);
@@ -715,7 +713,7 @@ CIMGUI_API void             igPopClipRect();
 
 // Utilities
 CIMGUI_API bool             igIsItemHovered();
-CIMGUI_API bool             igIsRectItemHovered();
+CIMGUI_API bool             igIsItemRectHovered();
 CIMGUI_API bool             igIsItemActive();
 CIMGUI_API bool             igIsItemClicked(int mouse_button);
 CIMGUI_API bool             igIsItemVisible();
@@ -824,8 +822,8 @@ CIMGUI_API void             ImDrawList_PushClipRectFullScreen(struct ImDrawList*
 CIMGUI_API void             ImDrawList_PopClipRect(struct ImDrawList* list);
 CIMGUI_API void             ImDrawList_PushTextureID(struct ImDrawList* list, CONST ImTextureID texture_id);
 CIMGUI_API void             ImDrawList_PopTextureID(struct ImDrawList* list);
-CIMGUI_API struct ImVec2    ImDrawList_GetClipRectMin(struct ImDrawList* list);
-CIMGUI_API struct ImVec2    ImDrawList_GetClipRectMax(struct ImDrawList* list);
+CIMGUI_API void             ImDrawList_GetClipRectMin(struct ImVec2 *pOut, struct ImDrawList* list);
+CIMGUI_API void             ImDrawList_GetClipRectMax(struct ImVec2 *pOut, struct ImDrawList* list);
 
 // Primitives
 CIMGUI_API void             ImDrawList_AddLine(struct ImDrawList* list, CONST struct ImVec2 a, CONST struct ImVec2 b, ImU32 col, float thickness);

--- a/cimgui/drawList.cpp
+++ b/cimgui/drawList.cpp
@@ -77,6 +77,16 @@ CIMGUI_API void ImDrawList_PopTextureID(ImDrawList* list)
 	return list->PopTextureID();
 }
 
+CIMGUI_API ImVec2 ImDrawList_GetClipRectMin(ImDrawList* list)
+{
+	return list->GetClipRectMin();
+}
+
+CIMGUI_API ImVec2 ImDrawList_GetClipRectMax(ImDrawList* list)
+{
+	return list->GetClipRectMax();
+}
+
 CIMGUI_API void ImDrawList_AddLine(ImDrawList* list, CONST struct ImVec2 a, CONST struct ImVec2 b, ImU32 col, float thickness)
 {
 	return list->AddLine(a, b, col, thickness);

--- a/cimgui/drawList.cpp
+++ b/cimgui/drawList.cpp
@@ -77,14 +77,14 @@ CIMGUI_API void ImDrawList_PopTextureID(ImDrawList* list)
 	return list->PopTextureID();
 }
 
-CIMGUI_API ImVec2 ImDrawList_GetClipRectMin(ImDrawList* list)
+CIMGUI_API void ImDrawList_GetClipRectMin(ImVec2* pOut, ImDrawList* list)
 {
-	return list->GetClipRectMin();
+	*pOut = list->GetClipRectMin();
 }
 
-CIMGUI_API ImVec2 ImDrawList_GetClipRectMax(ImDrawList* list)
+CIMGUI_API void ImDrawList_GetClipRectMax(ImVec2* pOut, ImDrawList* list)
 {
-	return list->GetClipRectMax();
+	*pOut = list->GetClipRectMax();
 }
 
 CIMGUI_API void ImDrawList_AddLine(ImDrawList* list, CONST struct ImVec2 a, CONST struct ImVec2 b, ImU32 col, float thickness)

--- a/cimgui/fontAtlas.cpp
+++ b/cimgui/fontAtlas.cpp
@@ -37,19 +37,19 @@ CIMGUI_API ImFont* ImFontAtlas_AddFontFromFileTTF(ImFontAtlas* atlas,CONST char*
 	return atlas->AddFontFromFileTTF(filename, size_pixels, font_cfg, glyph_ranges);
 }
 
-CIMGUI_API ImFont* ImFontAtlas_AddFontFromMemoryTTF(ImFontAtlas* atlas, void* ttf_data, int ttf_size, float size_pixels, CONST ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges)
+CIMGUI_API ImFont* ImFontAtlas_AddFontFromMemoryTTF(ImFontAtlas* atlas, void* font_data, int font_size, float size_pixels, CONST ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges)
 {
-	return atlas->AddFontFromMemoryTTF(ttf_data, ttf_size, size_pixels, font_cfg, glyph_ranges);
+	return atlas->AddFontFromMemoryTTF(font_data, font_size, size_pixels, font_cfg, glyph_ranges);
 }
 
-CIMGUI_API ImFont* ImFontAtlas_AddFontFromMemoryCompressedTTF(ImFontAtlas* atlas, CONST void* compressed_ttf_data, int compressed_ttf_size, float size_pixels, CONST ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges)
+CIMGUI_API ImFont* ImFontAtlas_AddFontFromMemoryCompressedTTF(ImFontAtlas* atlas, CONST void* compressed_font_data, int compressed_font_size, float size_pixels, CONST ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges)
 {
-	return atlas->AddFontFromMemoryCompressedTTF(compressed_ttf_data, compressed_ttf_size, size_pixels, font_cfg, glyph_ranges);
+	return atlas->AddFontFromMemoryCompressedTTF(compressed_font_data, compressed_font_size, size_pixels, font_cfg, glyph_ranges);
 }
 
-CIMGUI_API ImFont* ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(ImFontAtlas* atlas, CONST char* compressed_ttf_data_base85, float size_pixels, CONST ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges)
+CIMGUI_API ImFont* ImFontAtlas_AddFontFromMemoryCompressedBase85TTF(ImFontAtlas* atlas, CONST char* compressed_font_data_base85, float size_pixels, CONST ImFontConfig* font_cfg, CONST ImWchar* glyph_ranges)
 {
-	return atlas->AddFontFromMemoryCompressedBase85TTF(compressed_ttf_data_base85, size_pixels, font_cfg, glyph_ranges);
+	return atlas->AddFontFromMemoryCompressedBase85TTF(compressed_font_data_base85, size_pixels, font_cfg, glyph_ranges);
 }
 
 CIMGUI_API void ImFontAtlas_ClearTexData(ImFontAtlas* atlas)


### PR DESCRIPTION
I've updated the library to imgui 1.51. Some of the new functions were implemented, and I've also renamed 2 enum types to match. For example, `ImGuiSetCond` is now `ImGuiCond`.

I'm not the best at C, so feel free to make some edits.