### PR TITLE
Fix Cygwin build

### DIFF
--- a/cimgui/cimgui.h
+++ b/cimgui/cimgui.h
@@ -7,7 +7,7 @@
 #else
 #define API __declspec(dllexport)
 #endif
-#ifdef __GNUC__
+#ifndef __GNUC__
 #define snprintf sprintf_s
 #endif
 #else


### PR DESCRIPTION
It seems commit https://github.com/Extrawurst/cimgui/commit/516547dcd92426ca5bbdd68675a58158fb7968db #32 flipped `#ifndef` here.