### PR TITLE
Pass default_filter properly to ImGuiTextFilter constructor

### DIFF
--- a/cimgui/cimgui.cpp
+++ b/cimgui/cimgui.cpp
@@ -1611,7 +1611,7 @@ CIMGUI_API void ImGuiIO_ClearInputCharacters()
 CIMGUI_API struct ImGuiTextFilter* ImGuiTextFilter_Create(const char* default_filter)
 {
     ImGuiTextFilter* filter = (ImGuiTextFilter*)ImGui::MemAlloc(sizeof(ImGuiTextFilter));
-    IM_PLACEMENT_NEW(filter) ImGuiTextFilter();
+    IM_PLACEMENT_NEW(filter) ImGuiTextFilter(default_filter);
     return filter;
 }
 


### PR DESCRIPTION
This parameter was unused which resulted in a compiler warning:

```
warning: third-party/cimgui/cimgui/cimgui.cpp: In function ‘ImGuiTextFilter* ImGuiTextFilter_Create(const char*)’:
warning: third-party/cimgui/cimgui/cimgui.cpp:1611:71: warning: unused parameter ‘default_filter’ [-Wunused-parameter]
warning:  CIMGUI_API struct ImGuiTextFilter* ImGuiTextFilter_Create(const char* default_filter)
```